### PR TITLE
ci: add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "dotfiles",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for the dotfiles repo.
+# Provisions Bun (the package manager/runtime used by CI and the project
+# scripts) and installs pinned dependencies from the committed lockfile.
+set -euo pipefail
+
+export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+
+if ! command -v bun >/dev/null 2>&1; then
+  curl -fsSL https://bun.sh/install | bash
+fi
+
+export PATH="$BUN_INSTALL/bin:$PATH"
+
+# Expose bun/bunx on the system PATH so non-login shells and the agent's
+# install/start hooks find them without sourcing a shell profile.
+if command -v sudo >/dev/null 2>&1; then
+  sudo ln -sf "$BUN_INSTALL/bin/bun" /usr/local/bin/bun 2>/dev/null || true
+  sudo ln -sf "$BUN_INSTALL/bin/bunx" /usr/local/bin/bunx 2>/dev/null || true
+fi
+
+bun --version
+bun install --frozen-lockfile


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cloud Agent development environment for this repo so agents boot with a working Bun + TypeScript toolchain and the project's pinned dependencies already installed.

The repo had no `.cursor/environment.json`. This adds a repo-managed one (versioned with the branch, highest precedence) plus a small, idempotent bootstrap script. The default Cloud Agent base image already ships Node, but not Bun — which is what CI and every project script use — so the install step provisions it.

## What's included

- `.cursor/environment.json` — `name` + `install: bash .cursor/install.sh`.
- `.cursor/install.sh` — idempotent bootstrap:
  - installs Bun via the official installer only if it isn't already present;
  - symlinks `bun`/`bunx` into `/usr/local/bin` so non-login shells and hooks resolve them without sourcing a profile;
  - runs `bun install --frozen-lockfile` against the committed `bun.lock`.

No `start`/`terminals` are needed — this is a tooling repo with no long-running services.

## Validation

Validated on the local VM and on a **fresh Cloud Agent booted from the prebuilt build** produced from this branch:

| Check | Result |
| --- | --- |
| `bun install --frozen-lockfile` (idempotent) | Passed, no changes on re-run |
| `bun biome ci .` (matches GitHub CI) | Passed, 13 files, 0 fixes |
| `bun run check` (`tsgo --noEmit`) | Passed |
| `bun test` | 23/23 passing |
| `use-client` codemod end-to-end | Correctly adds `"use client"` to a client component, leaves a plain util untouched |

Build install log confirmed Bun `1.4.2` was provisioned and 24 packages installed on a fresh pod with exit code 0.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-841af748-13b9-40d8-997f-0b68b5546f63?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-841af748-13b9-40d8-997f-0b68b5546f63&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

