### PR TITLE
Add commit-my isolated commits and rename atomic-commits to commit-all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,3 +10,4 @@ jobs:
       - uses: ./.github/actions/setup-bun
       - run: bun install --frozen-lockfile
       - run: bun biome ci .
+      - run: bun test

--- a/aliases/commit-my.test.ts
+++ b/aliases/commit-my.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { chmod, lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+
+import { CommitMyError, run } from "../config/~/.agents/skills/commit-my/scripts/commit-my.js"
+
+type Repo = {
+  root: string
+  repo: string
+}
+
+const repos: string[] = []
+
+afterEach(async () => {
+  for (const root of repos.splice(0)) {
+    const repo = join(root, "repo")
+
+    try {
+      const porcelain = await git(repo, ["worktree", "list", "--porcelain"])
+
+      for (const line of porcelain.split("\n")) {
+        if (!line.startsWith("worktree ")) {
+          continue
+        }
+
+        const worktree = line.slice("worktree ".length)
+
+        if (worktree === repo) {
+          continue
+        }
+
+        await git(repo, ["worktree", "remove", "--force", worktree]).catch(() => undefined)
+        await rm(dirname(worktree), { recursive: true, force: true }).catch(() => undefined)
+      }
+    } catch {
+      // The repo may already be gone.
+    }
+
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+describe("commit-my", () => {
+  test("copies dirty files into a sandbox and leaves the shared tree unchanged", async () => {
+    const { repo } = await createRepo()
+
+    await writeFile(join(repo, "app.js"), "mine\n")
+    await rm(join(repo, "keep-me.txt"))
+    await writeFile(join(repo, "new-file.txt"), "untracked\n")
+    await mkdir(join(repo, "node_modules"), { recursive: true })
+    await writeFile(join(repo, "node_modules/pkg.js"), "ignored\n")
+    await writeFile(join(repo, ".env.local"), "SECRET=1\n")
+    await writeFile(join(repo, "other.js"), "theirs\n")
+
+    await git(repo, ["add", "keep-me.txt"])
+    const stagedBefore = await git(repo, ["diff", "--cached"])
+    const statusBefore = await git(repo, ["status", "--short"])
+    const appBefore = await readFile(join(repo, "app.js"), "utf8")
+
+    const started = await startSandbox(repo)
+    const sandboxStatus = await git(started.sandbox, ["status", "--short"])
+
+    expect(sandboxStatus).toContain("M app.js")
+    expect(sandboxStatus).toContain("D keep-me.txt")
+    expect(sandboxStatus).toContain("?? new-file.txt")
+    expect(sandboxStatus).toContain("M other.js")
+    expect(sandboxStatus).not.toContain(".env.local")
+    expect(await pathExists(join(started.sandbox, ".env.local"))).toBe(false)
+    expect(await git(repo, ["ls-tree", "-r", "--name-only", started.snapshotTree])).not.toContain("node_modules")
+    expect(await git(repo, ["ls-tree", "-r", "--name-only", started.snapshotTree])).not.toContain(".env.local")
+    expect((await lstat(join(started.sandbox, "node_modules"))).isSymbolicLink()).toBe(true)
+    expect(await git(repo, ["status", "--short"])).toBe(statusBefore)
+    expect(await git(repo, ["diff", "--cached"])).toBe(stagedBefore)
+    expect(await readFile(join(repo, "app.js"), "utf8")).toBe(appBefore)
+    expect(await pathExists(join(repo, "new-file.txt"))).toBe(true)
+    expect(await pathExists(join(repo, "keep-me.txt"))).toBe(false)
+
+    await run(["abort"], { cwd: started.sandbox, log: () => undefined, warn: () => undefined })
+  })
+
+  test("isolate drops unstaged files so hooks only see the commit candidate", async () => {
+    const { repo } = await createRepo()
+    const hook = join(repo, ".git/hooks/pre-commit")
+
+    await writeFile(
+      hook,
+      `#!/bin/sh
+if grep -q THEIRS_BROKEN other.js 2>/dev/null; then
+  echo "HOOK_SAW_OTHER_AGENT" >&2
+  exit 1
+fi
+`,
+    )
+    await chmod(hook, 0o755)
+
+    await writeFile(join(repo, "app.js"), "mine\n")
+    await writeFile(join(repo, "other.js"), "THEIRS_BROKEN\n")
+
+    const started = await startSandbox(repo)
+
+    await git(started.sandbox, ["add", "app.js"])
+    await run(["isolate"], { cwd: started.sandbox, log: () => undefined, warn: () => undefined })
+
+    const isolated = await git(started.sandbox, ["status", "--short"])
+
+    expect(isolated).toBe("M  app.js")
+    expect(await readFile(join(started.sandbox, "other.js"), "utf8")).toBe("base\n")
+    expect(await readFile(join(repo, "other.js"), "utf8")).toBe("THEIRS_BROKEN\n")
+
+    await git(started.sandbox, ["commit", "-m", "mine"])
+    await run(["finish"], { cwd: started.sandbox, log: () => undefined, warn: () => undefined })
+
+    expect(await git(repo, ["log", "-1", "--pretty=%s"])).toBe("mine")
+    expect(await git(repo, ["show", "HEAD:app.js"])).toBe("mine")
+    expect(await readFile(join(repo, "app.js"), "utf8")).toBe("mine\n")
+    expect(await readFile(join(repo, "other.js"), "utf8")).toBe("THEIRS_BROKEN\n")
+    expect(await git(repo, ["status", "--short"])).toBe(" M other.js")
+  })
+
+  test("refresh restores remaining snapshot files after an atomic commit", async () => {
+    const { repo } = await createRepo()
+
+    await writeFile(join(repo, "app.js"), "A\n")
+    await writeFile(join(repo, "other.js"), "B\n")
+
+    const started = await startSandbox(repo)
+
+    await git(started.sandbox, ["add", "app.js"])
+    await run(["isolate"], { cwd: started.sandbox, log: () => undefined, warn: () => undefined })
+    await git(started.sandbox, ["commit", "-m", "A"])
+    await run(["refresh"], { cwd: started.sandbox, log: () => undefined, warn: () => undefined })
+
+    expect(await git(started.sandbox, ["status", "--short"])).toBe(" M other.js")
+    expect(await readFile(join(started.sandbox, "app.js"), "utf8")).toBe("A\n")
+    expect(await readFile(join(started.sandbox, "other.js"), "utf8")).toBe("B\n")
+
+    await git(started.sandbox, ["add", "other.js"])
+    await run(["isolate"], { cwd: started.sandbox, log: () => undefined, warn: () => undefined })
+    await git(started.sandbox, ["commit", "-m", "B"])
+    await run(["finish"], { cwd: started.sandbox, log: () => undefined, warn: () => undefined })
+
+    expect(await git(repo, ["log", "--pretty=%s"])).toBe("B\nA\ninit")
+  })
+
+  test("finish rebases onto a moved branch without changing shared files", async () => {
+    const { repo } = await createRepo()
+
+    await writeFile(join(repo, "app.js"), "mine\n")
+    await writeFile(join(repo, "other.js"), "theirs\n")
+
+    const started = await startSandbox(repo)
+
+    await git(started.sandbox, ["add", "app.js"])
+    await run(["isolate"], { cwd: started.sandbox, log: () => undefined, warn: () => undefined })
+    await git(started.sandbox, ["commit", "-m", "mine"])
+
+    await writeFile(join(repo, "extra.txt"), "landed\n")
+    await git(repo, ["add", "extra.txt"])
+    await git(repo, ["commit", "-m", "landed"])
+    await writeFile(join(repo, "app.js"), "mine\n")
+    await writeFile(join(repo, "other.js"), "theirs\n")
+
+    const sharedBefore = await snapshotFiles(repo)
+
+    await run(["finish"], { cwd: started.sandbox, log: () => undefined, warn: () => undefined })
+
+    expect(await git(repo, ["log", "--pretty=%s"])).toBe("mine\nlanded\ninit")
+    expect(await snapshotFiles(repo)).toEqual(sharedBefore)
+    expect(await git(repo, ["status", "--short"])).toBe(" M other.js")
+  })
+
+  test("finish leaves a conflicted sandbox when replay is not conflict-free", async () => {
+    const { repo } = await createRepo()
+
+    await writeFile(join(repo, "app.js"), "mine\n")
+
+    const started = await startSandbox(repo)
+
+    await git(started.sandbox, ["add", "app.js"])
+    await run(["isolate"], { cwd: started.sandbox, log: () => undefined, warn: () => undefined })
+    await git(started.sandbox, ["commit", "-m", "mine"])
+
+    await writeFile(join(repo, "app.js"), "theirs\n")
+    await git(repo, ["add", "app.js"])
+    await git(repo, ["commit", "-m", "theirs"])
+    await writeFile(join(repo, "app.js"), "mine\n")
+
+    const beforeHead = await git(repo, ["rev-parse", "HEAD"])
+
+    let failed: unknown
+
+    try {
+      await run(["finish"], { cwd: started.sandbox, log: () => undefined, warn: () => undefined })
+    } catch (error) {
+      failed = error
+    }
+
+    expect(failed).toBeInstanceOf(CommitMyError)
+    expect(String(failed)).toContain("Rebase conflict")
+    expect(await git(repo, ["rev-parse", "HEAD"])).toBe(beforeHead)
+    expect(await readFile(join(repo, "app.js"), "utf8")).toBe("mine\n")
+    expect(await git(started.sandbox, ["status", "--short"])).toContain("UU app.js")
+
+    await run(["abort"], { cwd: started.sandbox, log: () => undefined, warn: () => undefined })
+    expect(await git(repo, ["worktree", "list"])).not.toContain(started.sandbox)
+  })
+
+  test("abort removes the sandbox and does not move the branch", async () => {
+    const { repo } = await createRepo()
+
+    await writeFile(join(repo, "app.js"), "mine\n")
+
+    const started = await startSandbox(repo)
+    const head = await git(repo, ["rev-parse", "HEAD"])
+
+    await git(started.sandbox, ["add", "app.js"])
+    await run(["isolate"], { cwd: started.sandbox, log: () => undefined, warn: () => undefined })
+    await git(started.sandbox, ["commit", "-m", "mine"])
+    await run(["abort"], { cwd: started.sandbox, log: () => undefined, warn: () => undefined })
+
+    expect(await git(repo, ["rev-parse", "HEAD"])).toBe(head)
+    expect(await git(repo, ["log", "-1", "--pretty=%s"])).toBe("init")
+    expect(await readFile(join(repo, "app.js"), "utf8")).toBe("mine\n")
+    expect(await git(repo, ["worktree", "list"])).not.toContain(started.sandbox)
+  })
+
+  test("start refuses a detached shared HEAD", async () => {
+    const { repo } = await createRepo()
+
+    await git(repo, ["checkout", "--detach", "HEAD"])
+
+    let failed: unknown
+
+    try {
+      await startSandbox(repo)
+    } catch (error) {
+      failed = error
+    }
+
+    expect(failed).toBeInstanceOf(CommitMyError)
+    expect(String(failed)).toContain("detached HEAD")
+  })
+})
+
+async function createRepo() {
+  const root = await mkdtemp(join(tmpdir(), "commit-my-test-"))
+  const repo = join(root, "repo")
+
+  repos.push(root)
+  await mkdir(repo)
+  await git(repo, ["init", "-b", "main"])
+  await git(repo, ["config", "user.email", "test@example.com"])
+  await git(repo, ["config", "user.name", "Test"])
+  await git(repo, ["config", "commit.gpgsign", "false"])
+  await writeFile(join(repo, ".gitignore"), "node_modules/\n.env.local\n")
+  await writeFile(join(repo, "app.js"), "base\n")
+  await writeFile(join(repo, "keep-me.txt"), "keep\n")
+  await writeFile(join(repo, "other.js"), "base\n")
+  await git(repo, ["add", "."])
+  await git(repo, ["commit", "-m", "init"])
+
+  return { root, repo } satisfies Repo
+}
+
+async function startSandbox(repo: string) {
+  const logs: string[] = []
+
+  await run(["start", "--json"], {
+    cwd: repo,
+    log: (message) => logs.push(message),
+    warn: () => undefined,
+  })
+
+  return JSON.parse(logs.join("\n")) as {
+    sandbox: string
+    branch: string
+    head: string
+    snapshotTree: string
+  }
+}
+
+async function snapshotFiles(repo: string) {
+  return {
+    app: await readFile(join(repo, "app.js"), "utf8"),
+    other: await readFile(join(repo, "other.js"), "utf8"),
+    extra: await readFile(join(repo, "extra.txt"), "utf8"),
+  }
+}
+
+async function pathExists(path: string) {
+  try {
+    await readFile(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function git(cwd: string, args: string[]) {
+  const proc = Bun.spawn(["git", "-C", cwd, ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+
+  if (code !== 0) {
+    throw new Error(stderr || stdout || `git ${args.join(" ")} failed`)
+  }
+
+  return stdout.trimEnd()
+}

--- a/aliases/git.sh
+++ b/aliases/git.sh
@@ -129,6 +129,11 @@ git-commit-with-ai() {
   git commit -m "$msg" "$@"
 }
 
+commit-my() {
+  local here="${SCRIPT_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)}"
+  bun run "$here/../config/~/.agents/skills/commit-my/scripts/commit-my.ts" "$@"
+}
+
 git-merge() {
   if [ ! -z $1 ]; then
     git merge $1

--- a/config/~/.agents/skills/commit-all/SKILL.md
+++ b/config/~/.agents/skills/commit-all/SKILL.md
@@ -1,13 +1,15 @@
 ---
-name: atomic-commits
-description: Use when the user wants existing uncommitted repository changes analyzed, split into logical atomic commits, staged, and committed without prescribing the grouping.
+name: commit-all
+description: Use when the user wants all existing uncommitted repository changes analyzed, split into logical atomic commits, staged, and committed without prescribing the grouping, or asks for /commit-all or atomic commits.
 argument-hint: "optional scope or commit-message convention"
 compatibility: Requires git
 ---
 
-# Atomic Commits
+# Commit All
 
-Turn the repository's current uncommitted work into a fine-grained sequence of coherent commits. Invoking this skill authorizes staging and committing the in-scope changes; do not ask the user to design the split.
+Turn the repository's current uncommitted work into a fine-grained sequence of coherent commits. Invoking this skill authorizes staging and committing the in-scope changes. Do not ask the user to design the split.
+
+If other agents have parallel uncommitted work in this working tree, use commit-my instead. This skill commits from the shared tree and is for when every dirty change is in scope.
 
 ## Understand the Change Set
 
@@ -23,7 +25,7 @@ Each commit should represent one reason to change the code: independently unders
 
 - Group changes by semantic purpose, not by file, directory, or time of editing.
 - Keep the same mechanical or configuration change across multiple packages together.
-- Separate distinct concerns even when they touch the same component or file—for example, visual styling, animation, and form behavior.
+- Separate distinct concerns even when they touch the same component or file, for example visual styling, animation, and form behavior.
 - Keep implementation with the tests, types, schemas, migrations, generated artifacts, and documentation required for that implementation.
 - Avoid artificial splits such as committing a helper and its sole use separately when they form one feature.
 - Order genuinely independent prerequisites before their consumers when that produces useful commits.
@@ -38,7 +40,7 @@ For each group:
 1. Arrange the index so it contains only that group. Existing staged changes may be safely unstaged for regrouping without altering the working tree. Do not stash, hide, or temporarily remove remaining changes while committing a group.
 2. Stage explicit paths when the whole file belongs to the group. When one file contains multiple concerns, stage selected hunks or construct and apply a precise cached patch. Never use broad staging commands such as `git add .` or `git add -A`.
 3. Review `git diff --cached --stat` and `git diff --cached`. Confirm the commit is complete, contains no unrelated hunks, and leaves the repository structurally valid for the next commit.
-4. Run focused, inexpensive checks when they materially reduce risk. Do not test every historical intermediate commit unless the user asks; use dependency-aware judgment to preserve a buildable sequence by construction.
+4. Run focused, inexpensive checks when they materially reduce risk. Do not test every historical intermediate commit unless the user asks. Use dependency-aware judgment to preserve a buildable sequence by construction.
 5. Commit with the repository's message convention and a message describing this commit's single intent. Do not bypass hooks.
 6. Reinspect status because hooks may modify files, then continue with the remaining groups.
 

--- a/config/~/.agents/skills/commit-my/SKILL.md
+++ b/config/~/.agents/skills/commit-my/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: commit-my
+description: Use when the user asks to commit only this agent's changes, run /commit-my, or commit from a shared working tree where other agents may have uncommitted work.
+argument-hint: "optional scope or commit-message convention"
+compatibility: Requires git
+---
+
+# Commit My
+
+Commit only your changes from a shared working tree. Create an isolated sandbox first so Lefthook, `tsc`, Biome, tests, and other commit hooks see your commit candidate, not other agents' in-progress files.
+
+Invoking this skill authorizes staging and committing your in-scope work. Do not ask the user to design the split. Do not modify, restore, stash, or clean the shared working tree. Forgotten work stays there.
+
+## Quick start
+
+1. In the shared repo, run `commit-my start` and `cd` into the printed sandbox. All later git and hook commands run there.
+2. Stage only your changes: `git add <path>`, `git add -p`, or a cached patch. Never `git add .` or `git add -A`.
+3. Run `commit-my isolate` so the sandbox working tree matches the index (`HEAD` + staged).
+4. Review `git diff --cached`. Commit with a normal `git commit` so hooks run. Do not bypass hooks.
+5. If checks fail, fix in the sandbox, stage, isolate if unstaged noise remains, and commit again.
+6. For another atomic commit of your remaining work, run `commit-my refresh`, then repeat from staging.
+7. Run `commit-my finish`. It replays your commits onto the current branch tip without touching shared files, then deletes the sandbox.
+
+On rebase conflicts, resolve in the sandbox and `git rebase --continue`, then `commit-my finish` again, or run `commit-my abort`.
+
+If `commit-my` is not on `PATH`, run this skill's `scripts/commit-my.ts` with bun.
+
+## What to commit
+
+Same grouping rules as commit-all: one reason per commit, grouped by semantic purpose, tests with implementation. Scope is **your** edits in this session, not every dirty file. Shared files need hunk selection (`git add -p` or `git apply --cached`).
+
+The sandbox starts with a copy of tracked modifications, deletions, and untracked non-ignored files. Ignored artifacts such as `node_modules` are not copied. Other agents' hunks may still be present until isolate. Leave them unstaged.
+
+## Commands
+
+- `commit-my start`: detached worktree at `HEAD`, copy relevant dirty files, prepare Lefthook if needed
+- `commit-my isolate`: `git restore .` and `git clean -fd` in the sandbox
+- `commit-my refresh`: restore the original snapshot against current sandbox `HEAD`
+- `commit-my finish`: rebase onto the live branch tip if it moved, fast-forward the branch ref, remove the sandbox
+- `commit-my abort`: remove the sandbox without integrating
+- `commit-my status`: print the active sandbox

--- a/config/~/.agents/skills/commit-my/scripts/commit-my.ts
+++ b/config/~/.agents/skills/commit-my/scripts/commit-my.ts
@@ -1,0 +1,576 @@
+#!/usr/bin/env bun
+
+import { access, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises"
+import { homedir, tmpdir } from "node:os"
+import { dirname, isAbsolute, join } from "node:path"
+
+const STATE_NAME = "commit-my-state.json"
+
+const LEFTHOOK_FILES = ["lefthook.yml", "lefthook.yaml", ".lefthook.yml", ".lefthook.yaml", "lefthook.toml"]
+
+const USAGE = `Usage: commit-my <command> [sandbox] [--json]
+
+Commands:
+  start     Create an isolated worktree sandbox and copy dirty files into it
+  isolate   Drop unstaged sandbox changes so the worktree matches the index
+  refresh   Restore remaining snapshot files after a sandbox commit
+  finish    Replay sandbox commits onto the current branch tip and delete the sandbox
+  abort     Delete the sandbox without integrating
+  status    Show the active sandbox
+  help      Show this help
+
+The shared working tree is never modified. Only finish updates the branch ref.`
+
+export class CommitMyError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "CommitMyError"
+  }
+}
+
+type CommitMyState = {
+  version: 1
+  sharedRoot: string
+  branch: string
+  startHead: string
+  snapshotTree: string
+  sandbox: string
+}
+
+type Io = {
+  cwd: string
+  log: (message: string) => void
+  warn: (message: string) => void
+}
+
+type GitResult = {
+  code: number
+  stdout: string
+  stderr: string
+}
+
+export async function run(argv: string[], io: Partial<Io> = {}) {
+  const cwd = io.cwd ?? process.cwd()
+  const log = io.log ?? console.log
+  const warn = io.warn ?? console.error
+  const ctx: Io = { cwd, log, warn }
+  const { command, sandboxArg, json } = parseArgs(argv)
+
+  if (!command || command === "help" || command === "-h" || command === "--help") {
+    log(USAGE)
+    return
+  }
+
+  switch (command) {
+    case "start":
+      await start(ctx, json)
+      return
+    case "isolate":
+      await isolate(ctx, sandboxArg)
+      return
+    case "refresh":
+      await refresh(ctx, sandboxArg)
+      return
+    case "finish":
+      await finish(ctx, sandboxArg)
+      return
+    case "abort":
+      await abort(ctx, sandboxArg)
+      return
+    case "status":
+      await status(ctx, sandboxArg, json)
+      return
+    default:
+      throw new CommitMyError(`Unknown command: ${command}\n\n${USAGE}`)
+  }
+}
+
+function parseArgs(argv: string[]) {
+  const json = argv.includes("--json")
+  const rest = argv.filter((arg) => arg !== "--json")
+  const command = rest[0]
+  const sandboxArg = rest[1]
+
+  return { command, sandboxArg, json }
+}
+
+async function start(io: Io, json: boolean) {
+  const sharedRoot = await requireRepoRoot(io.cwd)
+
+  await assertUsableSharedRepo(sharedRoot)
+
+  const branch = await gitText(sharedRoot, ["rev-parse", "--abbrev-ref", "HEAD"])
+
+  if (branch === "HEAD") {
+    throw new CommitMyError("commit-my requires a branch. The shared repository is in detached HEAD.")
+  }
+
+  const startHead = await gitText(sharedRoot, ["rev-parse", "HEAD"])
+  const snapshotTree = await writeSnapshotTree(sharedRoot)
+  const sandboxRoot = await mkdtemp(join(tmpdir(), "commit-my-"))
+  const sandbox = join(sandboxRoot, "work")
+
+  try {
+    await gitText(sharedRoot, ["worktree", "add", "--detach", sandbox, startHead])
+    await gitText(sandbox, ["restore", "--source", snapshotTree, "--worktree", "--no-overlay", "--", "."])
+    await prepareSandboxTooling(sharedRoot, sandbox, io.warn)
+
+    const state: CommitMyState = {
+      version: 1,
+      sharedRoot,
+      branch,
+      startHead,
+      snapshotTree,
+      sandbox,
+    }
+
+    await writeState(sandbox, state)
+  } catch (error) {
+    await removeSandbox(sharedRoot, sandbox)
+    await rm(sandboxRoot, { recursive: true, force: true })
+    throw error
+  }
+
+  if (json) {
+    io.log(
+      JSON.stringify(
+        {
+          sandbox,
+          branch,
+          head: startHead,
+          snapshotTree,
+        },
+        null,
+        2,
+      ),
+    )
+    return
+  }
+
+  io.log(`commit-my sandbox ready`)
+  io.log(`sandbox: ${sandbox}`)
+  io.log(`branch: ${branch}`)
+  io.log(`head: ${startHead}`)
+  io.log("")
+  io.log("cd into the sandbox, stage your changes, then:")
+  io.log("  commit-my isolate")
+  io.log("  git commit")
+  io.log("  commit-my refresh    # optional, for another atomic commit")
+  io.log("  commit-my finish")
+}
+
+async function isolate(io: Io, sandboxArg?: string) {
+  const state = await loadState(io, sandboxArg)
+
+  await gitText(state.sandbox, ["restore", "."])
+  await gitText(state.sandbox, ["clean", "-fd", "--exclude=node_modules"])
+  await prepareSandboxTooling(state.sharedRoot, state.sandbox, io.warn)
+
+  const statusText = await gitText(state.sandbox, ["status", "--short"])
+
+  io.log(statusText || "sandbox working tree matches the index")
+}
+
+async function refresh(io: Io, sandboxArg?: string) {
+  const state = await loadState(io, sandboxArg)
+
+  await gitText(state.sandbox, ["restore", "--source", state.snapshotTree, "--worktree", "--no-overlay", "--", "."])
+  await prepareSandboxTooling(state.sharedRoot, state.sandbox, io.warn)
+
+  const statusText = await gitText(state.sandbox, ["status", "--short"])
+
+  io.log(statusText || "no remaining snapshot changes")
+}
+
+async function finish(io: Io, sandboxArg?: string) {
+  const state = await loadState(io, sandboxArg)
+
+  await assertNoRebaseInProgress(state.sandbox)
+
+  const sandboxHead = await gitText(state.sandbox, ["rev-parse", "HEAD"])
+
+  if (sandboxHead === state.startHead) {
+    throw new CommitMyError("No commits in the sandbox. Commit first, or run commit-my abort.")
+  }
+
+  const currentHead = await gitText(state.sharedRoot, ["rev-parse", state.branch])
+
+  if (sandboxHead === currentHead) {
+    await removeSandbox(state.sharedRoot, state.sandbox)
+    io.log("nothing to integrate")
+    return
+  }
+
+  const mergeBase = await gitText(state.sandbox, ["merge-base", sandboxHead, currentHead])
+
+  if (mergeBase !== currentHead) {
+    const result = await git(state.sandbox, ["rebase", "--onto", currentHead, mergeBase])
+
+    if (result.code !== 0) {
+      throw new CommitMyError(
+        [
+          "Rebase conflict while integrating onto the current branch tip.",
+          "Resolve the conflict in the sandbox, then run git rebase --continue and commit-my finish.",
+          "Or run commit-my abort to drop the sandbox.",
+          `sandbox: ${state.sandbox}`,
+          result.stderr || result.stdout,
+        ].join("\n"),
+      )
+    }
+  }
+
+  const newTip = await gitText(state.sandbox, ["rev-parse", "HEAD"])
+
+  if (newTip !== currentHead) {
+    const updated = await git(state.sharedRoot, ["update-ref", `refs/heads/${state.branch}`, newTip, currentHead])
+
+    if (updated.code !== 0) {
+      throw new CommitMyError(
+        [
+          "Branch moved while integrating. Re-run commit-my finish.",
+          `sandbox: ${state.sandbox}`,
+          updated.stderr || updated.stdout,
+        ].join("\n"),
+      )
+    }
+
+    await refreshSharedIndex(state.sharedRoot, state.startHead, newTip)
+  }
+
+  const short = await gitText(state.sharedRoot, ["log", "--oneline", `${currentHead}..${newTip}`])
+
+  await removeSandbox(state.sharedRoot, state.sandbox)
+
+  io.log(short ? `integrated:\n${short}` : "integrated")
+}
+
+async function abort(io: Io, sandboxArg?: string) {
+  const state = await loadState(io, sandboxArg)
+
+  await git(state.sandbox, ["rebase", "--abort"])
+  await removeSandbox(state.sharedRoot, state.sandbox)
+
+  io.log(`removed sandbox ${state.sandbox}`)
+}
+
+async function status(io: Io, sandboxArg: string | undefined, json: boolean) {
+  const state = await loadState(io, sandboxArg)
+
+  if (json) {
+    io.log(JSON.stringify(state, null, 2))
+    return
+  }
+
+  io.log(`sandbox: ${state.sandbox}`)
+  io.log(`shared: ${state.sharedRoot}`)
+  io.log(`branch: ${state.branch}`)
+  io.log(`start: ${state.startHead}`)
+}
+
+async function writeSnapshotTree(sharedRoot: string) {
+  const indexDir = await mkdtemp(join(tmpdir(), "commit-my-index-"))
+  const indexPath = join(indexDir, "index")
+
+  try {
+    await gitText(sharedRoot, ["read-tree", "HEAD"], { GIT_INDEX_FILE: indexPath })
+    await gitText(sharedRoot, ["add", "-A"], { GIT_INDEX_FILE: indexPath })
+    return await gitText(sharedRoot, ["write-tree"], { GIT_INDEX_FILE: indexPath })
+  } finally {
+    await rm(indexDir, { recursive: true, force: true })
+  }
+}
+
+async function prepareSandboxTooling(sharedRoot: string, sandbox: string, warn: (message: string) => void) {
+  await linkPackageNodeModules(sharedRoot, sandbox)
+  await installLefthook(sandbox, warn)
+}
+
+async function linkPackageNodeModules(sharedRoot: string, sandbox: string) {
+  const dirs = new Set(["."])
+  const tracked = await gitText(sharedRoot, ["ls-files"])
+
+  for (const file of tracked.split("\n")) {
+    if (file.endsWith("package.json")) {
+      dirs.add(dirname(file))
+    }
+  }
+
+  for (const dir of dirs) {
+    const source = join(sharedRoot, dir, "node_modules")
+    const dest = join(sandbox, dir, "node_modules")
+
+    if (!(await pathExists(source)) || (await pathExists(dest))) {
+      continue
+    }
+
+    await mkdir(dirname(dest), { recursive: true })
+    await symlink(source, dest)
+  }
+}
+
+async function installLefthook(sandbox: string, warn: (message: string) => void) {
+  let hasConfig = false
+
+  for (const name of LEFTHOOK_FILES) {
+    if (await pathExists(join(sandbox, name))) {
+      hasConfig = true
+      break
+    }
+  }
+
+  if (!hasConfig) {
+    return
+  }
+
+  const binary = await findLefthook(sandbox)
+
+  if (!binary) {
+    warn("lefthook config found, but lefthook is not installed")
+    return
+  }
+
+  const result = await spawnCommand(sandbox, [binary, "install"])
+
+  if (result.code !== 0) {
+    warn(result.stderr || result.stdout || "lefthook install failed")
+  }
+}
+
+async function findLefthook(sandbox: string) {
+  const local = join(sandbox, "node_modules", ".bin", "lefthook")
+
+  if (await pathExists(local)) {
+    return local
+  }
+
+  const which = await spawnCommand(sandbox, ["sh", "-c", "command -v lefthook"])
+
+  if (which.code === 0 && which.stdout) {
+    return which.stdout
+  }
+}
+
+async function refreshSharedIndex(sharedRoot: string, startHead: string, newTip: string) {
+  const names = await gitText(sharedRoot, ["diff", "--name-only", "--diff-filter=ACDMRTUXB", `${startHead}..${newTip}`])
+  const paths = names.split("\n").filter(Boolean)
+
+  if (!paths.length) {
+    return
+  }
+
+  await git(sharedRoot, ["restore", "--staged", "--", ...paths])
+}
+
+async function removeSandbox(sharedRoot: string, sandbox: string) {
+  const result = await git(sharedRoot, ["worktree", "remove", "--force", sandbox])
+
+  if (result.code !== 0) {
+    await rm(sandbox, { recursive: true, force: true })
+    await git(sharedRoot, ["worktree", "prune"])
+  }
+
+  await rm(dirname(sandbox), { recursive: true, force: true })
+}
+
+async function loadState(io: Io, sandboxArg?: string): Promise<CommitMyState> {
+  if (sandboxArg) {
+    const sandbox = resolvePath(io.cwd, sandboxArg)
+    return readState(sandbox)
+  }
+
+  const fromCwd = await readStateIfPresent(io.cwd)
+
+  if (fromCwd) {
+    return fromCwd
+  }
+
+  const sharedRoot = await requireRepoRoot(io.cwd)
+  const matches = await listSandboxes(sharedRoot)
+
+  if (matches.length === 1) {
+    const only = matches[0]
+
+    if (only) {
+      return only
+    }
+  }
+
+  if (matches.length > 1) {
+    const paths = matches.map((state) => state.sandbox).join("\n")
+    throw new CommitMyError(`Multiple commit-my sandboxes exist. Pass one:\n${paths}`)
+  }
+
+  throw new CommitMyError("No commit-my sandbox found. Run commit-my start first.")
+}
+
+async function listSandboxes(sharedRoot: string) {
+  const porcelain = await gitText(sharedRoot, ["worktree", "list", "--porcelain"])
+  const found: CommitMyState[] = []
+
+  for (const line of porcelain.split("\n")) {
+    if (!line.startsWith("worktree ")) {
+      continue
+    }
+
+    const worktree = line.slice("worktree ".length)
+    const state = await readStateIfPresent(worktree)
+
+    if (state) {
+      found.push(state)
+    }
+  }
+
+  return found
+}
+
+async function writeState(sandbox: string, state: CommitMyState) {
+  const gitDir = await gitText(sandbox, ["rev-parse", "--absolute-git-dir"])
+  await writeFile(join(gitDir, STATE_NAME), `${JSON.stringify(state, null, 2)}\n`)
+}
+
+async function readState(sandbox: string) {
+  const state = await readStateIfPresent(sandbox)
+
+  if (!state) {
+    throw new CommitMyError(`Not a commit-my sandbox: ${sandbox}`)
+  }
+
+  return state
+}
+
+async function readStateIfPresent(sandbox: string) {
+  const gitDirResult = await git(sandbox, ["rev-parse", "--absolute-git-dir"])
+
+  if (gitDirResult.code !== 0) {
+    return
+  }
+
+  const statePath = join(gitDirResult.stdout, STATE_NAME)
+
+  if (!(await pathExists(statePath))) {
+    return
+  }
+
+  const parsed: unknown = JSON.parse(await readFile(statePath, "utf8"))
+
+  if (!isState(parsed)) {
+    throw new CommitMyError(`Invalid commit-my state at ${statePath}`)
+  }
+
+  return parsed
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function isState(value: unknown): value is CommitMyState {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  return (
+    value.version === 1 &&
+    typeof value.sharedRoot === "string" &&
+    typeof value.branch === "string" &&
+    typeof value.startHead === "string" &&
+    typeof value.snapshotTree === "string" &&
+    typeof value.sandbox === "string"
+  )
+}
+
+async function assertUsableSharedRepo(sharedRoot: string) {
+  const gitDir = await gitText(sharedRoot, ["rev-parse", "--absolute-git-dir"])
+  const blockers = ["rebase-merge", "rebase-apply", "MERGE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD"]
+
+  for (const name of blockers) {
+    if (await pathExists(join(gitDir, name))) {
+      throw new CommitMyError(`Shared repository has an in-progress ${name.replaceAll("_", " ").toLowerCase()}.`)
+    }
+  }
+}
+
+async function assertNoRebaseInProgress(sandbox: string) {
+  const gitDir = await gitText(sandbox, ["rev-parse", "--absolute-git-dir"])
+
+  if ((await pathExists(join(gitDir, "rebase-merge"))) || (await pathExists(join(gitDir, "rebase-apply")))) {
+    throw new CommitMyError(
+      `Rebase still in progress in the sandbox. Resolve conflicts, git rebase --continue, then commit-my finish.\nsandbox: ${sandbox}`,
+    )
+  }
+}
+
+async function requireRepoRoot(cwd: string) {
+  const result = await git(cwd, ["rev-parse", "--show-toplevel"])
+
+  if (result.code !== 0) {
+    throw new CommitMyError("Not inside a git repository.")
+  }
+
+  return result.stdout
+}
+
+async function gitText(cwd: string, args: string[], env: Record<string, string> = {}) {
+  const result = await git(cwd, args, env)
+
+  if (result.code !== 0) {
+    throw new CommitMyError(result.stderr || result.stdout || `git ${args.join(" ")} failed`)
+  }
+
+  return result.stdout
+}
+
+async function git(cwd: string, args: string[], env: Record<string, string> = {}): Promise<GitResult> {
+  return spawnCommand(cwd, ["git", "-C", cwd, ...args], env)
+}
+
+async function spawnCommand(cwd: string, argv: string[], env: Record<string, string> = {}): Promise<GitResult> {
+  const proc = Bun.spawn(argv, {
+    cwd,
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+
+  return {
+    code,
+    stdout: stdout.trimEnd(),
+    stderr: stderr.trimEnd(),
+  }
+}
+
+async function pathExists(path: string) {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function resolvePath(cwd: string, path: string) {
+  if (isAbsolute(path)) {
+    return path
+  }
+
+  if (path.startsWith("~/")) {
+    return join(homedir(), path.slice(2))
+  }
+
+  return join(cwd, path)
+}
+
+if (import.meta.main) {
+  try {
+    await run(process.argv.slice(2))
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(message)
+    process.exitCode = 1
+  }
+}

--- a/config/~/.agents/skills/stage/SKILL.md
+++ b/config/~/.agents/skills/stage/SKILL.md
@@ -153,16 +153,7 @@ Fix anything that is in scope for your task.
 
 This satisfies "the change to be complete in the sense that it compiles now, with all the current changes being on disk."
 
-If you want to be extra rigorous that *your commit alone* does not introduce breakage (when other parallel changes are not present):
-
-```bash
-git stash push --keep-index -m "other-agents-inflight"
-# At this point index == your staged changes only
-bun fix && bun run test
-git stash pop
-```
-
-If the stashed test fails, your change has an undeclared dependency on another agent's edit. Re-scope the tasks.
+If you want to be extra rigorous that *your commit alone* does not introduce breakage (when other parallel changes are not present), use commit-my instead of stashing. Never stash in a shared working tree: it would hide or conflict with other agents' in-flight work.
 
 ### 8. Commit (or hand off)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Parallel coding agents can now commit from a shared working tree without running Lefthook, `tsc`, Biome, or tests against other agents' unfinished files.

- Renames the **atomic-commits** skill to **commit-all** (same all-changes atomic split).
- Adds **commit-my**: an isolated detached Git worktree sandbox, a `commit-my` CLI, and a skill that tells agents to stage only their own hunks there.
- The shared working tree is left untouched. Forgotten work stays on disk. `finish` rebases onto the live branch tip and deletes the sandbox, including on failure paths.

## Workflow

1. `commit-my start` copies tracked modifications, deletions, and untracked non-ignored files into a detached worktree at `HEAD` (no `node_modules` / ignored artifacts).
2. The agent stages only their changes (`git add <path>`, `git add -p`).
3. `commit-my isolate` runs `git restore .` and `git clean -fd` so hooks see `HEAD` + staged.
4. Normal `git commit` in the sandbox (Lefthook is installed there when a config is present).
5. `commit-my refresh` restores remaining snapshot files for another atomic commit.
6. `commit-my finish` rebases onto the current branch tip, fast-forwards the branch ref, then removes the worktree. Conflicts stay in the sandbox (or `commit-my abort`).

## Tests

`bun test` covers copy/ignore behavior, hook isolation, refresh, rebase when HEAD moved, conflict abort, and shared-tree immutability. CI now runs `bun test` as well as Biome.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd8d7279-cd59-44f9-af3f-d7b6ca8b109c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd8d7279-cd59-44f9-af3f-d7b6ca8b109c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

